### PR TITLE
Edit default parameters from UI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -159,7 +159,7 @@ pub fn compare_params_floats_with_original(
         if (context.parameter_vals_float[i] < param_val as f32 - eps)
             || (context.parameter_vals_float[i] > param_val as f32 + eps)
         {
-            synchronisation_controller.mutate(SequencerMutation::SetParam(
+            synchronisation_controller.mutate(SequencerMutation::SetStepParam(
                 context.current_track as usize,
                 0,
                 context.selected_step as usize,
@@ -663,7 +663,7 @@ async fn ui_main(
                                                     let default_param = 0.0;
                                                     context.parameter_vals_float[i] = default_param;
                                                     synchronisation_controller.mutate(
-                                                        SequencerMutation::SetParam(
+                                                        SequencerMutation::SetStepParam(
                                                             context.current_track as usize,
                                                             0,
                                                             context.selected_step as usize,

--- a/src/sequencer.rs
+++ b/src/sequencer.rs
@@ -93,7 +93,7 @@ type ParamValue = u8;
 pub enum SequencerMutation {
     CreateStep(TrackNum, PatternNum, StepNum),
     RemoveStep(TrackNum, PatternNum, StepNum),
-    SetParam(TrackNum, PatternNum, StepNum, Parameter, ParamValue),
+    SetStepParam(TrackNum, PatternNum, StepNum, Parameter, ParamValue),
     RemoveParam(TrackNum, PatternNum, StepNum, Parameter),
     SetTrackParam(TrackNum, Parameter, ParamValue),
 }
@@ -138,7 +138,7 @@ impl Sequencer {
                 SequencerMutation::RemoveStep(track, pattern, step) => {
                     self.tracks[track].patterns[pattern].steps[step] = None;
                 }
-                SequencerMutation::SetParam(track, pattern, step, parameter, value) => {
+                SequencerMutation::SetStepParam(track, pattern, step, parameter, value) => {
                     if self.tracks[track].patterns[pattern].steps[step].is_none() {
                         self.tracks[track].patterns[pattern].steps[step] = Some(Step::default());
                     }

--- a/src/sequencer.rs
+++ b/src/sequencer.rs
@@ -95,6 +95,7 @@ pub enum SequencerMutation {
     RemoveStep(TrackNum, PatternNum, StepNum),
     SetParam(TrackNum, PatternNum, StepNum, Parameter, ParamValue),
     RemoveParam(TrackNum, PatternNum, StepNum, Parameter),
+    SetTrackParam(TrackNum, Parameter, ParamValue),
 }
 
 pub type CurrentStepData = [usize; 8];
@@ -156,6 +157,10 @@ impl Sequencer {
                         .as_mut()
                         .unwrap()
                         .parameters[parameter as usize] = None;
+                }
+                SequencerMutation::SetTrackParam(track_num, parameter, value) => {
+                    self.tracks[track_num].default_parameters.parameters[parameter as usize] =
+                        value;
                 }
             }
         }


### PR DESCRIPTION
I've added `SequencerMutation::SetTrackParam` for you to use, the editing works the same as with per-track parameters

## Goal

- Let users edit the default track parameters when there's no step selected